### PR TITLE
SEP 1: 支持从 Scaffolding 玩家获取 EasyTier 节点

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ scaffolding-mc-server-{port: uint16}。
 - 请求体：空
 - 响应体：玩家列表（包括房主）
 - 响应体格式（JSON）：
-- * 联机客户端执行了协议协商且双端支持 `NN:player_easytier_id` 协议：\[{ name: string, machine_id: string, vendor: string, kind: 'HOST' | 'GUEST' }\]
-  * 否则：\[{ name: string, machine_id: string, easytier_id: string, vendor: string, kind: 'HOST' | 'GUEST' }\]
+- * 联机客户端执行了协议协商且双端支持 `NN:player_easytier_id` 协议：\[{ name: string, machine_id: string, easytier_id: string, vendor: string, kind: 'HOST' | 'GUEST' }\]
+  * 否则：\[{ name: string, machine_id: string, vendor: string, kind: 'HOST' | 'GUEST' }\]
 
 > 联机中心应使用 machine_id 来作为所有节点的唯一标识符。
 
@@ -174,5 +174,6 @@ scaffolding-mc-server-{port: uint16}。
 6. 每隔 5s 发送一次 `c:player_ping` 心跳包。
 
 **基础协议** 包括：`c:ping`, `c:protocols`,` c:server_port`, `c:player_ping`, `c:player_profiles_list`。
+
 
 


### PR DESCRIPTION
# 动机

目前，Scaffolding 联机中心与联机客户端不能从 Scaffolding 玩家获取 EasyTier 节点，进而阻止了各联机节点从 EasyTier 上获取当前 NAT 类型、与某玩家之间的连通性、玩家 IP 等重要信息。

# 目标

- 允许各联机节点从 Scaffolding 玩家数据获取 EasyTier 节点 ID。

# 非目标

- 用 EasyTier 节点 ID 代替原先基于 machine_id 的玩家标识方案。
  EasyTier 节点 ID 是 **会话唯一** 的，因此不能作为玩家唯一标识符。

# 描述

加入 `NN:player_easytier_id` 协议。如果联机客户端和联机中心均支持该协议，则会在 `c:player_profiles_list` 和 `c:player_ping` 协议的响应/请求体 Scaffolding 玩家数据中添加 `easytier_id` 字段。该字段为字符串类型，内容为 EasyTier 节点 ID。

<img width="691" height="415" alt="20c8dc2dfb77cc0b62ed1e60d78cc7bd" src="https://github.com/user-attachments/assets/7c5692d9-427f-41fd-9d70-2dd15e190e77" />

该值可以通过解码 EasyTier CLI 的输出等方式获取。

# 风险与假设

- 如果联机中心未实现 `NN:player_easytier_id` 协议，实现了该协议的联机客户端也不能正确获取 easytier_id。

# 时间轴

- [ ] 本 SEP 得到社区 _认可_。
- [ ] 将协议命名空间 `NN` 占位符更改为 `c`。