### PR TITLE
SEP 3: 重新定义术语

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ scaffolding-mc-server-{port: uint16}。
 
 各联机客户端应根据硬件信息生成足够长的字符串，避免碰撞，并尽力保证对同一设备始终产出稳定的结果。
 
-#### 标准协议
+#### 标准请求类型
 
 ##### c:ping [核心请求类型]
 
@@ -152,7 +152,7 @@ scaffolding-mc-server-{port: uint16}。
 ##### c:player_profiles_list [核心请求类型]
 
 - 请求体：空
-- 响应体：玩家列表（包括房主）
+- 响应体：玩家列表（包括联机中心）
 - 响应体格式（JSON）：[{ name: string, machine_id: string, vendor: string, kind: 'HOST' | 'GUEST' }]
 
 #### 拓展请求类型


### PR DESCRIPTION
# 动机

目前 Scaffolding 协议文档存在以下问题：

- 混用“标准协议”，“通用协议”，“拓展协议”等称呼；
- 联机中心发现/联机信息获取协议与具体请求体均称呼为“协议”，但实际上具体请求体/响应体是联机信息获取协议的一部分。

这严重干扰了用户的理解。

# 目标

- 重新选择词语来区别以上概念。

# 非目标

- 实际更改协议规定不是目标。

# 描述

新协议文档将仅包括以下两个顶层协议：

- “联机中心发现协议”
- “联机中心获取协议”

“标准协议”，“通用协议”，“拓展协议”等将更名为“请求类型”，即：

- 核心请求类型：所有联机中心和联机房客都必须完整实现的最小请求类型集合，包括且：`c:ping`, `c:protocols`,` c:server_port`, `c:player_ping`, `c:player_profiles_list`；
- 标准请求类型：由 Scaffolding-MC 规范直接规定的请求类型，以 c (community) 作为命名空间的全部请求类型；
- 拓展请求类型：由社区自发实现的其他请求类型。

移除了“玩家”板块：这是历史遗留。