### PR TITLE
SEP 4: 加入实例共享协议

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ scaffolding-mc-server-{port: uint16}。
 - 响应体格式（JSON）：
 
 ```
+// 若非在线已有整合包
 {
     "status": true,
     "minecraft": "1.21.10",
@@ -197,6 +198,17 @@ scaffolding-mc-server-{port: uint16}。
 }
 ```
 
+```
+// 若为在线已有整合包
+{
+    "status": true,
+    "type": "modpack",
+    "source": "modrinth",
+    "projectId": "5ZwdcRci",
+    "fileId": "mmM8JfKR"
+}
+```
+
 各联机客户端可以自行实现协议，选用自己的命名空间。
 请尽量选用联机客户端的名称作为命名空间，以避免命名空间冲突！
 标准联机流程
@@ -209,4 +221,5 @@ scaffolding-mc-server-{port: uint16}。
 6. 每隔 5s 发送一次 `c:player_ping` 心跳包。
 
 **基础协议** 包括：`c:ping`, `c:protocols`,` c:server_port`, `c:player_ping`, `c:player_profiles_list`。
+
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,41 @@ scaffolding-mc-server-{port: uint16}。
 
 #### 拓展协议
 
+##### NN:host_instance_info
+
+- 请求体：空
+- 响应体：若房主开启了实例分享，则返回实例 Metadata；否则，返回 { status: false }
+- 响应体格式（JSON）：
+
+```
+{
+    "status": true,
+    "minecraft": "1.21.10",
+    "additions": [
+        {
+            "name": "fabric",
+            "version": "0.17.3"
+        },
+        {
+            "name": "optifine",
+            "version": "HD_U_J7_pre2"
+        }
+    ],
+    "resources": [
+        {
+            "path": "mods/example-mod.jar",
+            "url": "https://example.com/download/example-mod.jar",
+            "size": 123456
+        },
+        {
+            "path": "resourcepacks/example-resourcepack.zip",
+            "url": "https://example.com/download/example-resourcepack.zip",
+            "size": 123456
+        }
+    ]
+}
+```
+
 各联机客户端可以自行实现协议，选用自己的命名空间。
 请尽量选用联机客户端的名称作为命名空间，以避免命名空间冲突！
 标准联机流程
@@ -174,3 +209,4 @@ scaffolding-mc-server-{port: uint16}。
 6. 每隔 5s 发送一次 `c:player_ping` 心跳包。
 
 **基础协议** 包括：`c:ping`, `c:protocols`,` c:server_port`, `c:player_ping`, `c:player_profiles_list`。
+

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ scaffolding-mc-server-{port: uint16}。
 // 若非在线已有整合包
 {
     "status": true,
+    "type": "custom",
     "minecraft": "1.21.10",
     "additions": [
         {
@@ -186,12 +187,17 @@ scaffolding-mc-server-{port: uint16}。
     "resources": [
         {
             "path": "mods/example-mod.jar",
-            "url": "https://example.com/download/example-mod.jar",
+            "urls": [
+                "https://example.com/download/example-mod.jar",
+                "https://mirror.example.com/download/example-mod.jar"
+            ],
             "size": 123456
         },
         {
             "path": "resourcepacks/example-resourcepack.zip",
-            "url": "https://example.com/download/example-resourcepack.zip",
+            "urls": [
+                "https://example.com/download/example-resourcepack.zip"
+            ],
             "size": 123456
         }
     ]
@@ -221,5 +227,6 @@ scaffolding-mc-server-{port: uint16}。
 6. 每隔 5s 发送一次 `c:player_ping` 心跳包。
 
 **基础协议** 包括：`c:ping`, `c:protocols`,` c:server_port`, `c:player_ping`, `c:player_profiles_list`。
+
 
 


### PR DESCRIPTION
# 动机
目前，若玩家使用包含 Mod 的实例进行联机，将需要通过第三方平台同步实例信息。这增加了操作成本，且由于平台限速等原因体验不佳。我们可以整合可从在线平台获取的实例资源信息，从而优化这一过程。

# 目标
* 允许 Scaffolding 联机中心分享实例信息。
* 允许各联机节点从 Scaffolding 联机中心获取已分享的实例信息。

# 非目标
* 传输非在线平台资源。
  传输这些资源可能带来数据安全等风险，也会给 EasyTier 节点带来不小的压力。

# 描述
加入 `NN:host_instance_info` 协议。如果联机客户端和联机中心均支持该协议，则允许联机客户端发送该请求以获取实例信息。

实例信息需要由启动器自行获取并整合。

# 风险与假设
* 如果联机中心未实现 `NN:host_instance_info` 协议，实现了该协议的联机客户端也不能正确获取实例信息。

# 时间轴
* [ ]  本 SEP 得到社区 _认可_。
* [ ]  将协议命名空间 `NN` 占位符更改为 `c`。

